### PR TITLE
update twemoji and add twitter emoji replacement

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,10 @@
     {
       "matches": ["*://www.facebook.com/*"],
       "js": ["src/facebook.js"]
+    },
+    {
+      "matches": ["*://*.twitter.com/*", "*://*.x.com/*"],
+      "js": ["src/twitter.js"]
     }
   ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "twemojify",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twemojify",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@twemoji/api": "^15.0.3"
+        "@twemoji/api": "^16.0.1"
       },
       "devDependencies": {
         "@parcel/config-webextension": "^2.11.0",
@@ -2549,20 +2549,22 @@
       }
     },
     "node_modules/@twemoji/api": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@twemoji/api/-/api-15.0.3.tgz",
-      "integrity": "sha512-BI+4nY1o3NAtsMpSTXW2nNjlpanYZ3ndVhslxmGplahO7fgxqWrtAezBs5Yze7vbT98BVx8krJSpr6qJMgYCWw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@twemoji/api/-/api-16.0.1.tgz",
+      "integrity": "sha512-qe7QHeJKVLGNciwAMbu1S872PX5bt1RY0+0xqvN7gNQ+zd3MyRJ5n7dZowEJWYRAgTN5bAUGshD1YAmkFkyAkA==",
+      "license": "MIT AND CC-BY-4.0",
       "dependencies": {
-        "@twemoji/parser": "15.0.0",
+        "@twemoji/parser": "16.0.0",
         "fs-extra": "^8.0.1",
         "jsonfile": "^5.0.0",
         "universalify": "^0.1.2"
       }
     },
     "node_modules/@twemoji/parser": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@twemoji/parser/-/parser-15.0.0.tgz",
-      "integrity": "sha512-lh9515BNsvKSNvyUqbj5yFu83iIDQ77SwVcsN/SnEGawczhsKU6qWuogewN1GweTi5Imo5ToQ9s+nNTf97IXvg=="
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@twemoji/parser/-/parser-16.0.0.tgz",
+      "integrity": "sha512-jmuIjkp3OIaEemwMy3sArBwZSuZkRqmueGwRe2Zk4cFzbUJISFBJSZLDUUBNIgq3c+nY49ideYN2OiII6JUqwA==",
+      "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     }
   },
   "dependencies": {
-    "@twemoji/api": "^15.0.3"
+    "@twemoji/api": "^16.0.1"
   }
 }

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -1,0 +1,20 @@
+function replaceTwitterEmoji() {
+    const emoji = document.querySelectorAll(
+        'img[src*="abs-0.twimg.com/emoji"]:not(.twemojified), ' +
+        'img[src*="abs.twimg.com/emoji"]:not(.twemojified)'
+    );
+
+    for (const e of emoji) {
+        const alt = e.alt;
+        if (!alt) continue;
+
+        e.classList.add('twemojified');
+        e.setAttribute('old-src', e.src);
+        e.onerror = () => { e.src = e.getAttribute('old-src'); };
+
+        const codepoints = twemoji.convert.toCodePoint(alt);
+        e.src = `${twemoji.base}${twemoji.size}/${codepoints}${twemoji.ext}`;
+    }
+}
+
+window.twemojifyExt = replaceTwitterEmoji


### PR DESCRIPTION
## Summary
- Update @twemoji/api from 15.0.3 to 16.0.1
- Add support for replacing Twitter's outdated emoji images with latest Twemoji
- Targets emoji images from abs-0.twimg.com and abs.twimg.com domains
- Works on both twitter.com and x.com

## Why Twitter support is needed
Twitter/X hasn't updated their emoji library in over a year, leaving users with outdated emoji designs. This extension already replaces native emoji with the latest Twemoji (v16.0.1), but couldn't upgrade Twitter's own emoji images since they were rendered as `<img>` elements instead of text.